### PR TITLE
Tighten minimum deposit badges and restore feature icons

### DIFF
--- a/assets/css/templatemo-lugx-gaming.css
+++ b/assets/css/templatemo-lugx-gaming.css
@@ -745,11 +745,11 @@ Banner Style
   top: 20px;
   border-radius: 25px;
   background-color: #008af8;
-  font-size: 22px;
+  font-size: 14px;
   text-transform: uppercase;
   font-weight: 700;
   color: #fff;
-  padding: 4px 15px;
+  padding: 3px 12px;
 }
 
 .main-banner .right-image span.offer {
@@ -840,7 +840,7 @@ Trending Style
 .trending .item span.price em {
   font-style: normal;
   font-weight: 400;
-  font-size: 14px;
+  font-size: 10px;
   text-decoration: line-through;
   display: block;
 }
@@ -852,11 +852,11 @@ Trending Style
   top: 20px;
   border-radius: 10px;
   background-color: #008af8;
-  font-size: 17px;
+  font-size: 12px;
   text-transform: uppercase;
   font-weight: 600;
   color: #fff;
-  padding: 8px 15px 6px 15px;
+  padding: 6px 12px 4px 12px;
 }
 
 .trending .item .down-content {

--- a/index.html
+++ b/index.html
@@ -92,8 +92,8 @@ https://templatemo.com/tm-589-lugx-gaming
         <div class="col-lg-4 offset-lg-2">
           <div class="right-image">
             <img src="assets/images/banner-image.jpg" alt="">
-            <span class="price">$22</span>
-            <span class="offer">-40%</span>
+            <span class="price">minimum deposit $22</span>
+            <span class="offer">TOP 1</span>
           </div>
         </div>
       </div>
@@ -107,7 +107,7 @@ https://templatemo.com/tm-589-lugx-gaming
           <a href="#">
             <div class="item">
               <div class="image">
-                <img src="assets/images/featured-02.png" alt="" style="max-width: 44px;">
+                <i class="fa-solid fa-gift" aria-hidden="true" style="font-size: 44px;"></i>
               </div>
               <h4>Top Bonus Guides</h4>
             </div>
@@ -117,9 +117,9 @@ https://templatemo.com/tm-589-lugx-gaming
           <a href="#">
             <div class="item">
               <div class="image">
-                <img src="assets/images/featured-03.png" alt="" style="max-width: 44px;">
+                <i class="fa-solid fa-bolt" aria-hidden="true" style="font-size: 44px;"></i>
               </div>
-              <h4>Safety & Security Checks</h4>
+              <h4>Fast Payout Casinos</h4>
             </div>
           </a>
         </div>
@@ -127,7 +127,7 @@ https://templatemo.com/tm-589-lugx-gaming
           <a href="#">
             <div class="item">
               <div class="image">
-                <img src="assets/images/featured-04.png" alt="" style="max-width: 44px;">
+                <i class="fa-solid fa-gamepad" aria-hidden="true" style="font-size: 44px;"></i>
               </div>
               <h4>Game Library Highlights</h4>
             </div>
@@ -137,7 +137,7 @@ https://templatemo.com/tm-589-lugx-gaming
           <a href="#">
             <div class="item">
               <div class="image">
-                <img src="assets/images/featured-01.png" alt="" style="max-width: 44px;">
+                <i class="fa-solid fa-gem" aria-hidden="true" style="font-size: 44px;"></i>
               </div>
               <h4>VIP & Loyalty Insights</h4>
             </div>
@@ -153,7 +153,7 @@ https://templatemo.com/tm-589-lugx-gaming
         <div class="col-lg-6">
           <div class="section-heading">
             <h6>Hot Picks</h6>
-            <h2>Trending Casinos</h2>
+            <h2>top 4 casinos picked</h2>
           </div>
         </div>
         <div class="col-lg-6">
@@ -165,12 +165,12 @@ https://templatemo.com/tm-589-lugx-gaming
           <div class="item">
             <div class="thumb">
               <a href="product-details.html"><img src="assets/images/trending-01.jpg" alt=""></a>
-              <span class="price"><em>$28</em>$20</span>
+              <span class="price"><em>minimum deposit $28</em>minimum deposit $20</span>
             </div>
             <div class="down-content">
               <span class="category">Slots</span>
               <h4>Nova Royale Casino</h4>
-              <a href="product-details.html"><i class="fa fa-shopping-bag"></i></a>
+              <a href="product-details.html"><i class="fa fa-external-link-square"></i></a>
             </div>
           </div>
         </div>
@@ -178,12 +178,12 @@ https://templatemo.com/tm-589-lugx-gaming
           <div class="item">
             <div class="thumb">
               <a href="product-details.html"><img src="assets/images/trending-02.jpg" alt=""></a>
-              <span class="price">$44</span>
+              <span class="price">minimum deposit $44</span>
             </div>
             <div class="down-content">
               <span class="category">Live Dealer</span>
               <h4>Starlight Spins Resort</h4>
-              <a href="product-details.html"><i class="fa fa-shopping-bag"></i></a>
+              <a href="product-details.html"><i class="fa fa-external-link-square"></i></a>
             </div>
           </div>
         </div>
@@ -191,12 +191,12 @@ https://templatemo.com/tm-589-lugx-gaming
           <div class="item">
             <div class="thumb">
               <a href="product-details.html"><img src="assets/images/trending-03.jpg" alt=""></a>
-              <span class="price"><em>$64</em>$44</span>
+              <span class="price"><em>minimum deposit $64</em>minimum deposit $44</span>
             </div>
             <div class="down-content">
               <span class="category">Table Games</span>
               <h4>Emerald Mirage Club</h4>
-              <a href="product-details.html"><i class="fa fa-shopping-bag"></i></a>
+              <a href="product-details.html"><i class="fa fa-external-link-square"></i></a>
             </div>
           </div>
         </div>
@@ -204,12 +204,12 @@ https://templatemo.com/tm-589-lugx-gaming
           <div class="item">
             <div class="thumb">
               <a href="product-details.html"><img src="assets/images/trending-04.jpg" alt=""></a>
-              <span class="price">$32</span>
+              <span class="price">minimum deposit $32</span>
             </div>
             <div class="down-content">
               <span class="category">Jackpots</span>
               <h4>Celestial Fortune Hall</h4>
-              <a href="product-details.html"><i class="fa fa-shopping-bag"></i></a>
+              <a href="product-details.html"><i class="fa fa-external-link-square"></i></a>
             </div>
           </div>
         </div>
@@ -334,7 +334,7 @@ https://templatemo.com/tm-589-lugx-gaming
         </div>
         <div class="col-lg col-sm-6 col-xs-12">
           <div class="item">
-            <h4>Mobile Friendly</h4>
+            <h4>sports betting</h4>
             <div class="thumb">
               <a href="product-details.html"><img src="assets/images/categories-03.jpg" alt=""></a>
             </div>


### PR DESCRIPTION
## Summary
- shrink the hero badge and trending price tags so the minimum deposit copy is more compact
- swap the feature tiles to use Font Awesome solid icons that are guaranteed to render in the bundled set

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d82cd3ccf083328613387c15925ecf