### PR TITLE
Fix feature icons alignment and update diamond icon

### DIFF
--- a/assets/css/templatemo-lugx-gaming.css
+++ b/assets/css/templatemo-lugx-gaming.css
@@ -798,9 +798,10 @@ Services Style
 .features .item .image {
   width: 90px;
   height: 90px;
-  display: inline-block;
-  text-align: center;
-  line-height: 90px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto;
   background-color: #0071f8;
   border-radius: 50%;
   transition: all .3s;

--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@ https://templatemo.com/tm-589-lugx-gaming
           <a href="#">
             <div class="item">
               <div class="image">
-                <i class="fa fa-diamond" aria-hidden="true" style="font-size: 44px;"></i>
+                <i class="fa fa-gem" aria-hidden="true" style="font-size: 44px;"></i>
               </div>
               <h4>VIP & Loyalty Insights</h4>
             </div>


### PR DESCRIPTION
## Summary
- center the feature icons within their circular badge using flex alignment
- replace the deprecated diamond icon with the Font Awesome gem glyph so it renders correctly

## Testing
- not run (static site change)


------
https://chatgpt.com/codex/tasks/task_e_68d854a49cbc8332b1036ba1ec3f0a0f