### PR TITLE
Style sign-in popup header

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,11 +32,26 @@
         box-shadow: 0 24px 60px rgba(0, 0, 0, 0.15);
       }
 
+      .brand-modal .modal-dialog {
+        margin: 2.5rem auto;
+      }
+
       .brand-modal .modal-header {
-        background: linear-gradient(135deg, var(--brand-primary) 0%, var(--brand-accent) 100%);
+        background: #007aff;
         color: #fff;
         border-bottom: none;
-        align-items: flex-start;
+        align-items: center;
+        padding: 1.75rem 2.5rem;
+      }
+
+      .brand-modal .modal-header .modal-title,
+      .brand-modal .modal-header p {
+        color: #fff;
+      }
+
+      .brand-modal .modal-header > div {
+        flex: 1;
+        text-align: center;
       }
 
       .brand-modal .modal-header .btn-close {
@@ -44,7 +59,7 @@
       }
 
       .brand-modal .modal-body {
-        padding: 2rem;
+        padding: 2.5rem;
       }
 
       .brand-modal .form-label {
@@ -95,7 +110,7 @@
 
       .modal-footer {
         border-top: none;
-        padding: 0 2rem 2rem;
+        padding: 0 2.5rem 2.5rem;
       }
 
       .subscribe-success-icon {


### PR DESCRIPTION
## Summary
- recolor modal header to solid brand blue and ensure header text renders in white
- center header content and expand modal padding for a roomier, more balanced layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da528aa4ac83329b9015fa86eb5d9f