### PR TITLE
Adjust pros list spacing

### DIFF
--- a/product-details.html
+++ b/product-details.html
@@ -175,7 +175,7 @@
 
       .review-accordion .list-with-icons li {
         font-size: 0.9rem;
-        margin-bottom: 0.5rem;
+        margin-bottom: 0;
       }
 
       .review-accordion .list-with-icons li i {


### PR DESCRIPTION
## Summary
- remove the extra spacing between pros list items in the product details accordion so they appear grouped together.

## Testing
- not run (HTML/CSS change)


------
https://chatgpt.com/codex/tasks/task_e_68dbb0a9f80c83329f23d0bb3e5362fb