### PR TITLE
Remove Product Details menu link

### DIFF
--- a/all-casinos.html
+++ b/all-casinos.html
@@ -58,7 +58,6 @@ https://templatemo.com/tm-589-lugx-gaming
                     <ul class="nav">
                       <li><a href="index.html">Home</a></li>
                       <li><a href="all-casinos.html" class="active">All Casinos</a></li>
-                      <li><a href="product-details.html">Product Details</a></li>
                       <li><a href="contact.html">Contact Us</a></li>
                       <li><a href="#">Sign In</a></li>
                   </ul>   

--- a/contact.html
+++ b/contact.html
@@ -58,7 +58,6 @@ https://templatemo.com/tm-589-lugx-gaming
                     <ul class="nav">
                       <li><a href="index.html">Home</a></li>
                       <li><a href="all-casinos.html">All Casinos</a></li>
-                      <li><a href="product-details.html">Product Details</a></li>
                       <li><a href="contact.html" class="active">Contact Us</a></li>
                       <li><a href="#">Sign In</a></li>
                   </ul>   

--- a/index.html
+++ b/index.html
@@ -163,7 +163,6 @@ https://templatemo.com/tm-589-lugx-gaming
                     <ul class="nav">
                       <li><a href="index.html" class="active">Home</a></li>
                       <li><a href="all-casinos.html">all casinos</a></li>
-                      <li><a href="product-details.html">top 4 casinos</a></li>
                       <li><a href="contact.html">Contact Us</a></li>
                       <li><a href="#" data-bs-toggle="modal" data-bs-target="#signInModal">Sign In</a></li>
                   </ul>

--- a/product-details.html
+++ b/product-details.html
@@ -261,7 +261,6 @@ https://templatemo.com/tm-589-lugx-gaming
                     <ul class="nav">
                       <li><a href="index.html">Home</a></li>
                       <li><a href="all-casinos.html">All Casinos</a></li>
-                      <li><a href="product-details.html" class="active">Product Details</a></li>
                       <li><a href="contact.html">Contact Us</a></li>
                       <li><a href="#">Sign In</a></li>
                   </ul>   


### PR DESCRIPTION
## Summary
- remove the Product Details/top 4 casinos navigation item from all pages
- keep main navigation limited to home, all casinos, contact, and sign-in

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc52a7aa10833285514d608d29948e