### PR TITLE
Add fast payout image gallery section

### DIFF
--- a/fast-payout-casinos.php
+++ b/fast-payout-casinos.php
@@ -63,6 +63,80 @@ include __DIR__ . '/partials/header.php';
     </div>
   </div>
 
+  <div class="section">
+    <div class="container">
+      <div class="row align-items-center mb-4">
+        <div class="col-lg-8">
+          <div class="section-heading">
+            <h6>Fast Payout Visuals</h6>
+            <h2>Inside the workflows that keep cashouts quick</h2>
+          </div>
+        </div>
+        <div class="col-lg-4 text-lg-end">
+          <p class="mb-0 text-muted">Verified process snapshots and banking touchpoints.</p>
+        </div>
+      </div>
+      <div class="row g-4">
+        <div class="col-lg-3 col-md-4 col-sm-6">
+          <div class="item">
+            <div class="thumb">
+              <img src="assets/images/fast-payout/processing-metrics.png" alt="Payout processing metrics dashboard">
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-3 col-md-4 col-sm-6">
+          <div class="item">
+            <div class="thumb">
+              <img src="assets/images/fast-payout/crypto-cashouts.png" alt="Crypto cashouts tracking visuals">
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-3 col-md-4 col-sm-6">
+          <div class="item">
+            <div class="thumb">
+              <img src="assets/images/fast-payout/e-wallets.png" alt="E-wallet speed performance tiles">
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-3 col-md-4 col-sm-6">
+          <div class="item">
+            <div class="thumb">
+              <img src="assets/images/fast-payout/bank-wires.png" alt="Bank wire payout schedule chart">
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-3 col-md-4 col-sm-6">
+          <div class="item">
+            <div class="thumb">
+              <img src="assets/images/fast-payout/KYC-refresh-rules.png" alt="KYC refresh rules checklist">
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-3 col-md-4 col-sm-6">
+          <div class="item">
+            <div class="thumb">
+              <img src="assets/images/fast-payout/VIP-queueing.png" alt="VIP queueing priority overview">
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-3 col-md-4 col-sm-6">
+          <div class="item">
+            <div class="thumb">
+              <img src="assets/images/fast-payout/caps-escalations.png" alt="Cashout caps and escalation guide">
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-3 col-md-4 col-sm-6">
+          <div class="item">
+            <div class="thumb">
+              <img src="assets/images/fast-payout/escalation-paths.png" alt="Escalation paths for payout issues">
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <div class="section most-played">
     <div class="container">
       <div class="row">


### PR DESCRIPTION
### Motivation
- Add visual context to the Fast Payout Casinos page by surfacing process snapshots stored in `assets/images/fast-payout`.
- Help readers quickly understand payout workflows and common banking touchpoints through an image gallery.

### Description
- Insert a new section between the trending highlights and the banking checklist with heading and short description. 
- Add a responsive grid of eight images that reference files in `assets/images/fast-payout` and include descriptive `alt` attributes. 
- No backend queries or database changes were made; this is purely presentational markup in `fast-payout-casinos.php`.

### Testing
- Started a local PHP dev server with `php -S 0.0.0.0:8000 -t /workspace/casino` and loaded `/fast-payout-casinos.php` successfully. 
- Captured a full-page screenshot using Playwright which produced `artifacts/fast-payout-casinos.png` confirming the new gallery renders. 
- Verified the change was staged and committed locally with `git commit` (commit message: "Add fast payout image gallery").

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69794b3aeadc8332958d4bda3735e711)