### PR TITLE
Update VIP loyalty insights image paths

### DIFF
--- a/vip-loyalty-insights.php
+++ b/vip-loyalty-insights.php
@@ -43,28 +43,28 @@ $vipSignals = dedupeContentCards($vipSignals);
 if (empty($vipPlaybooks)) {
     $vipPlaybooks = [
         [
-            'image_path' => 'assets/images/trending-01.jpg',
+            'image_path' => 'assets/images/vip-loyalty-insights/accelerate-early-progress.png',
             'badge' => 'Tier 1',
             'category' => 'Onboarding',
             'title' => 'First 30 Days Blueprint',
             'description' => 'Hit early wagering goals, unlock support access, and track weekly lift metrics.',
         ],
         [
-            'image_path' => 'assets/images/trending-02.jpg',
+            'image_path' => 'assets/images/vip-loyalty-insights/unlock-priority-support.png',
             'badge' => 'Tier 2',
             'category' => 'Momentum',
             'title' => 'Seasonal Bonus Radar',
             'description' => 'Plan around promo calendars, leaderboard surges, and reload rhythm windows.',
         ],
         [
-            'image_path' => 'assets/images/trending-03.jpg',
+            'image_path' => 'assets/images/vip-loyalty-insights/custom-rewards.png',
             'badge' => 'Tier 3',
             'category' => 'Retention',
             'title' => 'Concierge Access Map',
             'description' => 'Trigger VIP outreach with session cadence, game mix, and deposit timing.',
         ],
         [
-            'image_path' => 'assets/images/trending-04.jpg',
+            'image_path' => 'assets/images/vip-loyalty-insights/travel-hospitality.png',
             'badge' => 'Tier 4',
             'category' => 'Elite',
             'title' => 'High-Roller Safeguards',
@@ -76,25 +76,25 @@ if (empty($vipPlaybooks)) {
 if (empty($vipSignals)) {
     $vipSignals = [
         [
-            'image_path' => 'assets/images/bonus-page/top-game-01.png',
+            'image_path' => 'assets/images/vip-loyalty-insights/point-mechanics.png',
             'category' => 'Perks',
             'title' => 'Cashback Velocity',
             'description' => 'Measure how quickly you can redeem cashback after peak play sessions.',
         ],
         [
-            'image_path' => 'assets/images/bonus-page/top-game-02.png',
+            'image_path' => 'assets/images/vip-loyalty-insights/what-you-can-claim.png',
             'category' => 'Support',
             'title' => 'Concierge Response Time',
             'description' => 'Look for under-30 minute replies when hosts manage withdrawals.',
         ],
         [
-            'image_path' => 'assets/images/bonus-page/top-game-03.png',
+            'image_path' => 'assets/images/vip-loyalty-insights/keep-your-status.png',
             'category' => 'Events',
             'title' => 'Invite-Only Calendar',
             'description' => 'Track live tournaments, travel offers, and seasonal VIP stacks.',
         ],
         [
-            'image_path' => 'assets/images/bonus-page/top-game-04.png',
+            'image_path' => 'assets/images/vip-loyalty-insights/events-hospitality.png',
             'category' => 'Limits',
             'title' => 'Withdrawal Priority',
             'description' => 'Confirm fast-track lanes and personalized payout thresholds.',


### PR DESCRIPTION
### Motivation
- Replace legacy image references with new `assets/images/vip-loyalty-insights` asset names for the VIP playbook and loyalty signal fallback cards to prepare for upcoming image uploads.

### Description
- Updated the default `$vipPlaybooks` image paths in `vip-loyalty-insights.php` to `assets/images/vip-loyalty-insights/accelerate-early-progress.png`, `unlock-priority-support.png`, `custom-rewards.png`, and `travel-hospitality.png`.
- Updated the default `$vipSignals` image paths in `vip-loyalty-insights.php` to `assets/images/vip-loyalty-insights/point-mechanics.png`, `what-you-can-claim.png`, `keep-your-status.png`, and `events-hospitality.png`.
- Preserved the existing `dedupeContentCards` logic and all card metadata (titles, categories, badges, descriptions) while swapping only the image paths.

### Testing
- Launched a local PHP dev server with `php -S 0.0.0.0:8000 -t /workspace/casino` and the page served successfully.
- Captured a screenshot of `vip-loyalty-insights.php` using a Playwright Python script (`sync_playwright`) which produced the artifact `artifacts/vip-loyalty-insights.png`.
- No unit tests exist for this content-only change; automated smoke tests above succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69795a8adbdc8332961a3884bd7e705b)