### PR TITLE
Update VIP loyalty insights imagery

### DIFF
--- a/vip-loyalty-insights.php
+++ b/vip-loyalty-insights.php
@@ -43,28 +43,28 @@ $vipSignals = dedupeContentCards($vipSignals);
 if (empty($vipPlaybooks)) {
     $vipPlaybooks = [
         [
-            'image_path' => 'assets/images/trending-01.jpg',
+            'image_path' => 'assets/images/vip-loyalty-insights/accelerate-early-progress.png',
             'badge' => 'Tier 1',
             'category' => 'Onboarding',
             'title' => 'First 30 Days Blueprint',
             'description' => 'Hit early wagering goals, unlock support access, and track weekly lift metrics.',
         ],
         [
-            'image_path' => 'assets/images/trending-02.jpg',
+            'image_path' => 'assets/images/vip-loyalty-insights/unlock-priority-support.png',
             'badge' => 'Tier 2',
             'category' => 'Momentum',
             'title' => 'Seasonal Bonus Radar',
             'description' => 'Plan around promo calendars, leaderboard surges, and reload rhythm windows.',
         ],
         [
-            'image_path' => 'assets/images/trending-03.jpg',
+            'image_path' => 'assets/images/vip-loyalty-insights/custom-rewards.png',
             'badge' => 'Tier 3',
             'category' => 'Retention',
             'title' => 'Concierge Access Map',
             'description' => 'Trigger VIP outreach with session cadence, game mix, and deposit timing.',
         ],
         [
-            'image_path' => 'assets/images/trending-04.jpg',
+            'image_path' => 'assets/images/vip-loyalty-insights/travel-hospitality.png',
             'badge' => 'Tier 4',
             'category' => 'Elite',
             'title' => 'High-Roller Safeguards',
@@ -76,25 +76,25 @@ if (empty($vipPlaybooks)) {
 if (empty($vipSignals)) {
     $vipSignals = [
         [
-            'image_path' => 'assets/images/bonus-page/top-game-01.png',
+            'image_path' => 'assets/images/vip-loyalty-insights/point-mechanics.png',
             'category' => 'Perks',
             'title' => 'Cashback Velocity',
             'description' => 'Measure how quickly you can redeem cashback after peak play sessions.',
         ],
         [
-            'image_path' => 'assets/images/bonus-page/top-game-02.png',
+            'image_path' => 'assets/images/vip-loyalty-insights/what-you-can-claim.png',
             'category' => 'Support',
             'title' => 'Concierge Response Time',
             'description' => 'Look for under-30 minute replies when hosts manage withdrawals.',
         ],
         [
-            'image_path' => 'assets/images/bonus-page/top-game-03.png',
+            'image_path' => 'assets/images/vip-loyalty-insights/keep-your-status.png',
             'category' => 'Events',
             'title' => 'Invite-Only Calendar',
             'description' => 'Track live tournaments, travel offers, and seasonal VIP stacks.',
         ],
         [
-            'image_path' => 'assets/images/bonus-page/top-game-04.png',
+            'image_path' => 'assets/images/vip-loyalty-insights/events-hospitality.png',
             'category' => 'Limits',
             'title' => 'Withdrawal Priority',
             'description' => 'Confirm fast-track lanes and personalized payout thresholds.',


### PR DESCRIPTION
### Motivation
- Align the VIP & Loyalty Insights page with the new `assets/images/vip-loyalty-insights` art assets so default cards show the updated imagery.
- Replace legacy `trending-*` and `bonus-page/top-game-*` placeholder paths with descriptive image filenames for clarity and maintainability.

### Description
- Updated image paths for the default `$vipPlaybooks` entries to use `assets/images/vip-loyalty-insights/accelerate-early-progress.png`, `unlock-priority-support.png`, `custom-rewards.png`, and `travel-hospitality.png` in `vip-loyalty-insights.php`.
- Updated image paths for the default `$vipSignals` entries to use `assets/images/vip-loyalty-insights/point-mechanics.png`, `what-you-can-claim.png`, `keep-your-status.png`, and `events-hospitality.png` in `vip-loyalty-insights.php`.
- No other logic or layout changes were made; the `dedupeContentCards` helper and rendering markup remain unchanged.

### Testing
- Started a local PHP dev server with `php -S 0.0.0.0:8000 -t .` and confirmed the site served the updated page successfully.
- Captured a full-page screenshot of `vip-loyalty-insights.php` using a Playwright script which produced `artifacts/vip-loyalty-insights.png` successfully.
- No automated unit tests were added or run because this is a content/path update only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69796c1c2bb88332a74e262c5a6afdcf)