### PR TITLE
Map legacy VIP image paths to new vip-loyalty-insights assets

### DIFF
--- a/vip-loyalty-insights.php
+++ b/vip-loyalty-insights.php
@@ -40,6 +40,35 @@ function dedupeContentCards(array $cards): array
 $vipPlaybooks = dedupeContentCards($vipPlaybooks);
 $vipSignals = dedupeContentCards($vipSignals);
 
+$vipImageMap = [
+    'assets/images/trending-01.jpg' => 'assets/images/vip-loyalty-insights/accelerate-early-progress.png',
+    'assets/images/trending-02.jpg' => 'assets/images/vip-loyalty-insights/unlock-priority-support.png',
+    'assets/images/trending-03.jpg' => 'assets/images/vip-loyalty-insights/custom-rewards.png',
+    'assets/images/trending-04.jpg' => 'assets/images/vip-loyalty-insights/travel-hospitality.png',
+    'assets/images/top-game-13.jpg' => 'assets/images/vip-loyalty-insights/point-mechanics.png',
+    'assets/images/top-game-14.jpg' => 'assets/images/vip-loyalty-insights/what-you-can-claim.png',
+    'assets/images/top-game-15.jpg' => 'assets/images/vip-loyalty-insights/keep-your-status.png',
+    'assets/images/top-game-16.jpg' => 'assets/images/vip-loyalty-insights/events-hospitality.png',
+];
+
+$vipPlaybooks = array_map(static function (array $card) use ($vipImageMap): array {
+    $imagePath = $card['image_path'] ?? '';
+    if (isset($vipImageMap[$imagePath])) {
+        $card['image_path'] = $vipImageMap[$imagePath];
+    }
+
+    return $card;
+}, $vipPlaybooks);
+
+$vipSignals = array_map(static function (array $card) use ($vipImageMap): array {
+    $imagePath = $card['image_path'] ?? '';
+    if (isset($vipImageMap[$imagePath])) {
+        $card['image_path'] = $vipImageMap[$imagePath];
+    }
+
+    return $card;
+}, $vipSignals);
+
 if (empty($vipPlaybooks)) {
     $vipPlaybooks = [
         [


### PR DESCRIPTION
### Motivation
- Ensure older hard-coded image references are replaced with the new `assets/images/vip-loyalty-insights` images so the VIP & Loyalty Insights page shows the correct assets.
- Provide a server-side, non-destructive mapping so database-provided cards that still reference legacy paths render with updated images.

### Description
- Added a `$vipImageMap` associative array in `vip-loyalty-insights.php` mapping legacy paths (e.g. `assets/images/trending-01.jpg`) to the new `assets/images/vip-loyalty-insights/*` files.
- Applied the map to both `$vipPlaybooks` and `$vipSignals` using `array_map` to replace `image_path` values when a legacy key is found.
- Kept existing deduplication and fallback/default card definitions unchanged.

### Testing
- Started a local PHP dev server with `php -S 0.0.0.0:8000` and confirmed the server started successfully.
- Rendered the page with a Playwright script that opened `http://localhost:8000/vip-loyalty-insights.php` and captured a screenshot, which completed successfully and produced `artifacts/vip-loyalty-insights.png`.
- Code changes were validated by running the page in the dev server and observing the updated images render as expected in the screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69796e2b76788332b46e11fe6f0580d2)