### PR TITLE
Disable card links on content pages

### DIFF
--- a/fast-payout-casinos.php
+++ b/fast-payout-casinos.php
@@ -61,7 +61,7 @@ include __DIR__ . '/partials/header.php';
           <div class="col-lg-3 col-md-6 align-self-center mb-30 trending-items">
             <div class="item">
               <div class="thumb">
-                <a href="product-details.php"><img src="<?= htmlspecialchars(payoutImage($card['image_path'], $imageSwap), ENT_QUOTES, 'UTF-8') ?>" alt="<?= htmlspecialchars($card['title'], ENT_QUOTES, 'UTF-8') ?>"></a>
+                <img src="<?= htmlspecialchars(payoutImage($card['image_path'], $imageSwap), ENT_QUOTES, 'UTF-8') ?>" alt="<?= htmlspecialchars($card['title'], ENT_QUOTES, 'UTF-8') ?>">
                 <?php if (!empty($card['badge'])): ?>
                   <span class="price"><?= htmlspecialchars($card['badge'], ENT_QUOTES, 'UTF-8') ?></span>
                 <?php endif; ?>
@@ -96,7 +96,7 @@ include __DIR__ . '/partials/header.php';
           <div class="col-lg-3 col-md-6 col-sm-6">
             <div class="item">
               <div class="thumb">
-                <a href="product-details.php"><img src="<?= htmlspecialchars(payoutImage($card['image_path'], $imageSwap), ENT_QUOTES, 'UTF-8') ?>" alt="<?= htmlspecialchars($card['title'], ENT_QUOTES, 'UTF-8') ?>"></a>
+                <img src="<?= htmlspecialchars(payoutImage($card['image_path'], $imageSwap), ENT_QUOTES, 'UTF-8') ?>" alt="<?= htmlspecialchars($card['title'], ENT_QUOTES, 'UTF-8') ?>">
               </div>
               <div class="down-content">
                   <span class="category"><?= htmlspecialchars($card['category'], ENT_QUOTES, 'UTF-8') ?></span>

--- a/game-library-highlights.php
+++ b/game-library-highlights.php
@@ -52,7 +52,7 @@ include __DIR__ . '/partials/header.php';
           <div class="col-lg-3 col-md-6 align-self-center mb-30 trending-items">
             <div class="item">
               <div class="thumb">
-                <a href="product-details.php"><img src="<?= htmlspecialchars($card['image_path'], ENT_QUOTES, 'UTF-8') ?>" alt="<?= htmlspecialchars($card['title'], ENT_QUOTES, 'UTF-8') ?>"></a>
+                <img src="<?= htmlspecialchars($card['image_path'], ENT_QUOTES, 'UTF-8') ?>" alt="<?= htmlspecialchars($card['title'], ENT_QUOTES, 'UTF-8') ?>">
                 <?php if (!empty($card['badge'])): ?>
                   <span class="price"><?= htmlspecialchars($card['badge'], ENT_QUOTES, 'UTF-8') ?></span>
                 <?php endif; ?>
@@ -88,7 +88,7 @@ include __DIR__ . '/partials/header.php';
           <div class="col-lg-3 col-md-6 col-sm-6">
             <div class="item">
               <div class="thumb">
-                <a href="product-details.php"><img src="<?= htmlspecialchars($signalImage, ENT_QUOTES, 'UTF-8') ?>" alt="<?= htmlspecialchars($card['title'], ENT_QUOTES, 'UTF-8') ?>"></a>
+                <img src="<?= htmlspecialchars($signalImage, ENT_QUOTES, 'UTF-8') ?>" alt="<?= htmlspecialchars($card['title'], ENT_QUOTES, 'UTF-8') ?>">
               </div>
               <div class="down-content">
                   <span class="category"><?= htmlspecialchars($card['category'], ENT_QUOTES, 'UTF-8') ?></span>

--- a/top-bonus-guides.php
+++ b/top-bonus-guides.php
@@ -46,7 +46,7 @@ include __DIR__ . '/partials/header.php';
           <div class="col-lg-3 col-md-6 align-self-center mb-30 trending-items">
             <div class="item">
               <div class="thumb">
-                <a href="product-details.php"><img src="<?= htmlspecialchars($card['image_path'], ENT_QUOTES, 'UTF-8') ?>" alt="<?= htmlspecialchars($card['title'], ENT_QUOTES, 'UTF-8') ?>"></a>
+                <img src="<?= htmlspecialchars($card['image_path'], ENT_QUOTES, 'UTF-8') ?>" alt="<?= htmlspecialchars($card['title'], ENT_QUOTES, 'UTF-8') ?>">
                 <?php if (!empty($card['badge'])): ?>
                   <span class="price"><?= htmlspecialchars($card['badge'], ENT_QUOTES, 'UTF-8') ?></span>
                 <?php endif; ?>
@@ -81,7 +81,7 @@ include __DIR__ . '/partials/header.php';
           <div class="col-lg-3 col-md-6 col-sm-6">
             <div class="item">
               <div class="thumb">
-                <a href="product-details.php"><img src="<?= htmlspecialchars($card['image_path'], ENT_QUOTES, 'UTF-8') ?>" alt="<?= htmlspecialchars($card['title'], ENT_QUOTES, 'UTF-8') ?>"></a>
+                <img src="<?= htmlspecialchars($card['image_path'], ENT_QUOTES, 'UTF-8') ?>" alt="<?= htmlspecialchars($card['title'], ENT_QUOTES, 'UTF-8') ?>">
               </div>
               <div class="down-content">
                   <span class="category"><?= htmlspecialchars($card['category'], ENT_QUOTES, 'UTF-8') ?></span>

--- a/vip-loyalty-insights.php
+++ b/vip-loyalty-insights.php
@@ -166,7 +166,7 @@ include __DIR__ . '/partials/header.php';
           <div class="col-lg-3 col-md-6 align-self-center mb-30 trending-items">
             <div class="item">
               <div class="thumb">
-                <a href="product-details.php"><img src="<?= htmlspecialchars($card['image_path'], ENT_QUOTES, 'UTF-8') ?>" alt="<?= htmlspecialchars($card['title'], ENT_QUOTES, 'UTF-8') ?>"></a>
+                <img src="<?= htmlspecialchars($card['image_path'], ENT_QUOTES, 'UTF-8') ?>" alt="<?= htmlspecialchars($card['title'], ENT_QUOTES, 'UTF-8') ?>">
                 <?php if (!empty($card['badge'])): ?>
                   <span class="price"><?= htmlspecialchars($card['badge'], ENT_QUOTES, 'UTF-8') ?></span>
                 <?php endif; ?>
@@ -201,7 +201,7 @@ include __DIR__ . '/partials/header.php';
           <div class="col-lg-3 col-md-6 col-sm-6">
             <div class="item">
               <div class="thumb">
-                <a href="product-details.php"><img src="<?= htmlspecialchars($card['image_path'], ENT_QUOTES, 'UTF-8') ?>" alt="<?= htmlspecialchars($card['title'], ENT_QUOTES, 'UTF-8') ?>"></a>
+                <img src="<?= htmlspecialchars($card['image_path'], ENT_QUOTES, 'UTF-8') ?>" alt="<?= htmlspecialchars($card['title'], ENT_QUOTES, 'UTF-8') ?>">
               </div>
               <div class="down-content">
                   <span class="category"><?= htmlspecialchars($card['category'], ENT_QUOTES, 'UTF-8') ?></span>


### PR DESCRIPTION
### Motivation
- Cards on several content pages linked to `product-details.php`, but the design requires non-clickable cards so thumbnails should not navigate; this change removes those anchor wrappers. 
- No external skill was used; changes were applied directly to the four page templates for clarity and minimal surface area.

### Description
- Removed anchor tags wrapping thumbnail images on `top-bonus-guides.php`, `fast-payout-casinos.php`, `game-library-highlights.php`, and `vip-loyalty-insights.php` and left the `<img>` elements in place so visuals and badges remain. 
- Preserved badge, category, title, and description markup and any image-mapping helpers so content rendering and layout are unchanged aside from clickability. 
- Committed the edits with the message `Disable card links on content pages`.

### Testing
- Launched a local PHP server with `php -S 0.0.0.0:8000 -t /workspace/casino` which started successfully to serve the updated pages. 
- Attempted an automated visual smoke test with Playwright to capture screenshots, but the headless Chromium run failed with a crash (SIGSEGV) so the visual check did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979824f6b708332b5f698ffc52bd4f3)